### PR TITLE
Pin docker version to fix travis build failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
-  - sudo apt-get -y install docker-ce
+  - sudo apt-get -y install docker-ce=18.03.0~ce-0~ubuntu
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   - export TEMP_IMAGE="howtoadhd/travis-dump:howtoadhd_dev-services__${TRAVIS_COMMIT}"
 


### PR DESCRIPTION
Latest version of docker requires interactive input for use of --password